### PR TITLE
Fix up Travis CI and Python version support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: xenial
 language: "python"
 dist: xenial
 python:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-dist: xenial
 language: "python"
 dist: xenial
 python:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: "python"
 dist: xenial
 python:
    - "2.7"
-   - "3.4"
    - "3.5"
    - "3.6"
    - "3.7"

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,6 @@ Changes
 
 - Tie Travis CI to jazzband instance
 - Remove EOL 3.3 and 3.4 version support
-- Add 3.7 version support
 
   - https://github.com/jazzband/python-geojson/pull/120
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,15 @@
 Changes
 =======
 
+2.4.2 (2019-03-12)
+------------------
+
+- Tie Travis CI to jazzband instance
+- Remove EOL 3.3 and 3.4 version support
+- Add 3.7 version support
+
+  - https://github.com/jazzband/python-geojson/pull/120
+
 2.4.1 (2018-10-17)
 ------------------
 

--- a/README.rst
+++ b/README.rst
@@ -21,7 +21,7 @@ This library contains:
 Installation
 ------------
 
-python-geojson is compatible with Python 2.7, 3.5, and 3.6. It is listed on `PyPi as 'geojson'`_. The recommended way to install is via pip_:
+python-geojson is compatible with Python 2.7, 3.5, 3.6 and 3.7. It is listed on `PyPi as 'geojson'`_. The recommended way to install is via pip_:
 
 .. code::
 

--- a/README.rst
+++ b/README.rst
@@ -21,7 +21,7 @@ This library contains:
 Installation
 ------------
 
-python-geojson is compatible with Python 2.7, 3.3, 3.4, 3.5 and 3.6. It is listed on `PyPi as 'geojson'`_. The recommended way to install is via pip_:
+python-geojson is compatible with Python 2.7, 3.5, 3.6 and 3.7. It is listed on `PyPi as 'geojson'`_. The recommended way to install is via pip_:
 
 .. code::
 

--- a/README.rst
+++ b/README.rst
@@ -21,7 +21,7 @@ This library contains:
 Installation
 ------------
 
-python-geojson is compatible with Python 2.7, 3.5, 3.6 and 3.7. It is listed on `PyPi as 'geojson'`_. The recommended way to install is via pip_:
+python-geojson is compatible with Python 2.7, 3.5, and 3.6. It is listed on `PyPi as 'geojson'`_. The recommended way to install is via pip_:
 
 .. code::
 

--- a/geojson/_version.py
+++ b/geojson/_version.py
@@ -1,2 +1,2 @@
-__version__ = "2.4.1"
+__version__ = "2.4.2"
 __version_info__ = tuple(map(int, __version__.split(".")))

--- a/setup.py
+++ b/setup.py
@@ -31,8 +31,8 @@ def test_suite():
 
 major_version, minor_version = sys.version_info[:2]
 if not ((major_version == 2 and minor_version == 7)
-        or (major_version == 3 and minor_version >= 5)):
-    sys.stderr.write("Sorry, only Python 2.7, and 3.5 and up are supported "
+        or (major_version == 3 and minor_version in (5, 6))):
+    sys.stderr.write("Sorry, only Python 2.7, 3.5, and 3.6 are supported "
                      "at this time.\n")
     exit(1)
 
@@ -69,7 +69,6 @@ setup(
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: 3.7",
         "Topic :: Scientific/Engineering :: GIS",
     ]
 )

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setup(
     author_email="sgillies@frii.com",
     maintainer="Corey Farwell",
     maintainer_email="coreyf@rwell.org",
-    url="https://github.com/frewsxcv/python-geojson",
+    url="https://github.com/jazzband/python-geojson",
     long_description=readme_text,
     packages=["geojson"],
     package_dir={"geojson": "geojson"},

--- a/setup.py
+++ b/setup.py
@@ -29,9 +29,10 @@ def test_suite():
     return suite
 
 
-if sys.version_info[:2] not in [(2, 6), (2, 7)] and \
-        sys.version_info[:1] not in [(3, )]:
-    sys.stderr.write("Sorry, only Python 2.7, and 3.x are supported "
+major_version, minor_version = sys.version_info[:2]
+if not ((major_version == 2 and minor_version == 7)
+        or (major_version == 3 and minor_version >= 5)):
+    sys.stderr.write("Sorry, only Python 2.7, and 3.5 and up are supported "
                      "at this time.\n")
     exit(1)
 
@@ -66,7 +67,6 @@ setup(
         "Programming Language :: Python :: 2",
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",

--- a/setup.py
+++ b/setup.py
@@ -31,8 +31,8 @@ def test_suite():
 
 major_version, minor_version = sys.version_info[:2]
 if not ((major_version == 2 and minor_version == 7)
-        or (major_version == 3 and minor_version >= 5)):  # secretly allow 3.7+
-    sys.stderr.write("Sorry, only Python 2.7, 3.5, and 3.6 are supported "
+        or (major_version == 3 and minor_version >= 5)):
+    sys.stderr.write("Sorry, only Python 2.7, 3.5, 3.6 and 3.7 are supported "
                      "at this time.\n")
     exit(1)
 
@@ -69,6 +69,7 @@ setup(
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
         "Topic :: Scientific/Engineering :: GIS",
     ]
 )

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ def test_suite():
 
 major_version, minor_version = sys.version_info[:2]
 if not ((major_version == 2 and minor_version == 7)
-        or (major_version == 3 and minor_version in (5, 6))):
+        or (major_version == 3 and minor_version >= 5)):  # secretly allow 3.7+
     sys.stderr.write("Sorry, only Python 2.7, 3.5, and 3.6 are supported "
                      "at this time.\n")
     exit(1)

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py{27,35,36}, pypy, pypy3
+envlist = py{27,35,36,37}, pypy, pypy3
 
 [testenv]
 commands = {envpython} setup.py test

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py{27,35,36,37}, pypy, pypy3
+envlist = py{27,35,36}, pypy
 
 [testenv]
 commands = {envpython} setup.py test

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py{27,35,36}, pypy
+envlist = py{27,35,36}, pypy, pypy3
 
 [testenv]
 commands = {envpython} setup.py test

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py{27,34,35,36,37}, pypy, pypy3
+envlist = py{27,35,36,37}, pypy, pypy3
 
 [testenv]
 commands = {envpython} setup.py test


### PR DESCRIPTION
- Tie Travis CI to jazzband instance
- Remove EOL 3.3 and 3.4 version support
- Add 3.7 version support

The broken URL "details" link for the Travis CI build on https://github.com/jazzband/python-geojson/pull/119 led me to discover these issues.