### PR TITLE
fix unittest deprecation warnings

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -369,7 +369,9 @@ generate_random
 Development
 -----------
 
-To build this project, run :code:`python setup.py build`. To run the unit tests, run :code:`python setup.py test`.
+To build this project, run :code:`python setup.py build`.
+To run the unit tests, run :code:`python setup.py test`.
+To run the style checks, run :code:`flake8` (install `flake8` if needed).
 
 Credits
 -------

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -61,7 +61,7 @@ class BaseTestCase(unittest.TestCase):
 
     def test_to_instance(self):
         FAKE = 'fake'
-        self.assertEquals(FAKE, geojson.GeoJSON.to_instance(
+        self.assertEqual(FAKE, geojson.GeoJSON.to_instance(
             None, (lambda: FAKE)))
 
         with self.assertRaises(ValueError):

--- a/tests/test_constructor.py
+++ b/tests/test_constructor.py
@@ -13,21 +13,21 @@ class TestGeoJSONConstructor(unittest.TestCase):
     def test_copy_construction(self):
         coords = [1, 2]
         pt = geojson.Point(coords)
-        self.assertEquals(geojson.Point(pt), pt)
+        self.assertEqual(geojson.Point(pt), pt)
 
     def test_nested_constructors(self):
         a = [5, 6]
         b = [9, 10]
         c = [-5, 12]
         mp = geojson.MultiPoint([geojson.Point(a), b])
-        self.assertEquals(mp.coordinates, [a, b])
+        self.assertEqual(mp.coordinates, [a, b])
 
         mls = geojson.MultiLineString([geojson.LineString([a, b]), [a, c]])
-        self.assertEquals(mls.coordinates, [[a, b], [a, c]])
+        self.assertEqual(mls.coordinates, [[a, b], [a, c]])
 
         outer = [a, b, c, a]
         poly = geojson.Polygon(geojson.MultiPoint(outer))
         other = [[1, 1], [1, 2], [2, 1], [1, 1]]
         poly2 = geojson.Polygon([outer, other])
-        self.assertEquals(geojson.MultiPolygon([poly, poly2]).coordinates,
+        self.assertEqual(geojson.MultiPolygon([poly, poly2]).coordinates,
                           [[outer], [outer, other]])

--- a/tests/test_constructor.py
+++ b/tests/test_constructor.py
@@ -30,4 +30,4 @@ class TestGeoJSONConstructor(unittest.TestCase):
         other = [[1, 1], [1, 2], [2, 1], [1, 1]]
         poly2 = geojson.Polygon([outer, other])
         self.assertEqual(geojson.MultiPolygon([poly, poly2]).coordinates,
-                          [[outer], [outer, other]])
+                         [[outer], [outer, other]])

--- a/tests/test_geo_interface.py
+++ b/tests/test_geo_interface.py
@@ -138,10 +138,10 @@ class EncodingDecodingTest(unittest.TestCase):
         self.assertIn('is not JSON compliant', str(cm.exception))
 
     def test_mapping(self):
-        self.assertEquals(to_mapping(geojson.Point([1, 2])),
+        self.assertEqual(to_mapping(geojson.Point([1, 2])),
                           {"coordinates": [1, 2], "type": "Point"})
 
     def test_GeoJSON(self):
-        self.assertEquals(None, geojson.GeoJSON().__geo_interface__)
+        self.assertEqual(None, geojson.GeoJSON().__geo_interface__)
 
-        self.assertEquals({"type": "GeoJSON"}, to_mapping(geojson.GeoJSON()))
+        self.assertEqual({"type": "GeoJSON"}, to_mapping(geojson.GeoJSON()))

--- a/tests/test_geo_interface.py
+++ b/tests/test_geo_interface.py
@@ -139,7 +139,7 @@ class EncodingDecodingTest(unittest.TestCase):
 
     def test_mapping(self):
         self.assertEqual(to_mapping(geojson.Point([1, 2])),
-                          {"coordinates": [1, 2], "type": "Point"})
+                         {"coordinates": [1, 2], "type": "Point"})
 
     def test_GeoJSON(self):
         self.assertEqual(None, geojson.GeoJSON().__geo_interface__)


### PR DESCRIPTION
- change occurences of deprecated `AssertEquals()` to preferred `AssertEqual()`