### PR TITLE
Fix map_geometries() loss of feature IDs

### DIFF
--- a/geojson/utils.py
+++ b/geojson/utils.py
@@ -120,11 +120,14 @@ def map_geometries(func, obj):
         return {'type': obj['type'], 'geometries': geoms}
     elif obj['type'] == 'Feature':
         geom = func(obj['geometry']) if obj['geometry'] else None
-        return {
+        result = {
             'type': obj['type'],
             'geometry': geom,
             'properties': obj['properties'],
         }
+        if 'id' in obj:
+            result['id'] = obj['id']
+        return result
     elif obj['type'] == 'FeatureCollection':
         feats = [map_geometries(func, feat) for feat in obj['features']]
         return {'type': obj['type'], 'features': feats}

--- a/tests/test_coords.py
+++ b/tests/test_coords.py
@@ -80,7 +80,10 @@ class CoordsTestCase(unittest.TestCase):
         result = map_tuples(lambda t: t, f)
         self.assertEqual(result['type'], 'Feature')
         self.assertEqual(result['id'], '0')
-        self.assertEqual(result['geometry']['coordinates'], (-77.1291115237051, 38.7993076720178))
+        self.assertEqual(
+            result['geometry']['coordinates'],
+            (-77.1291115237051, 38.7993076720178)
+        )
 
     def test_map_invalid(self):
         with self.assertRaises(ValueError):

--- a/tests/test_coords.py
+++ b/tests/test_coords.py
@@ -1,7 +1,7 @@
 import unittest
 
 import geojson
-from geojson.utils import coords, map_coords
+from geojson.utils import coords, map_coords, map_tuples
 
 
 class CoordsTestCase(unittest.TestCase):
@@ -65,6 +65,22 @@ class CoordsTestCase(unittest.TestCase):
         self.assertEqual(result['type'], 'MultiPolygon')
         self.assertEqual(result['coordinates'][0][0][0], (3.78, 9.28))
         self.assertEqual(result['coordinates'][-1][-1][-1], (23.18, -34.29))
+
+    def test_map_feature(self):
+        f = geojson.Feature(
+            id='0',
+            geometry=geojson.Point([-77.1291115237051, 38.7993076720178]),
+            properties={
+                'name': 'Van Dorn Street',
+                'marker-col': '#0000ff',
+                'marker-sym': 'rail-metro',
+                'line': 'blue',
+            },
+        )
+        result = map_tuples(lambda t: t, f)
+        self.assertEqual(result['type'], 'Feature')
+        self.assertEqual(result['id'], '0')
+        self.assertEqual(result['geometry']['coordinates'], (-77.1291115237051, 38.7993076720178))
 
     def test_map_invalid(self):
         with self.assertRaises(ValueError):


### PR DESCRIPTION
I noticed that a Feature passed to `geojson.utils.map_tuples()` loses it's ID. Here is a [simple replication](https://repl.it/@bryik/python-geojson-lib-maptuple-removes-IDs).

The cause seems to be that IDs are [not included in the dict returned by geojson.utils.map_geometry()](https://github.com/jazzband/python-geojson/blob/master/geojson/utils.py#L123).

**This PR:**
- adds the ID to the dict aca22cb
- adds a test to check ID is present after mapping f3e876a
 
