### PR TITLE
Add default lat/lon precision to base Geometry class

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -49,7 +49,7 @@ Point
   >>> from geojson import Point
 
   >>> Point((-115.81, 37.24))  # doctest: +ELLIPSIS
-  {"coordinates": [-115.8..., 37.2...], "type": "Point"}
+  {"coordinates": [-115.81, 37.24], "type": "Point"}
 
 Visualize the result of the example above `here <https://gist.github.com/frewsxcv/b5768a857f5598e405fa>`__. General information about Point can be found in `Section 3.1.2`_ and `Appendix A: Points`_ within `The GeoJSON Format Specification`_.
 
@@ -64,7 +64,7 @@ MultiPoint
   >>> from geojson import MultiPoint
 
   >>> MultiPoint([(-155.52, 19.61), (-156.22, 20.74), (-157.97, 21.46)])  # doctest: +ELLIPSIS
-  {"coordinates": [[-155.5..., 19.6...], [-156.2..., 20.7...], [-157.9..., 21.4...]], "type": "MultiPoint"}
+  {"coordinates": [[-155.52, 19.61], [-156.22, 20.74], [-157.97, 21.46]], "type": "MultiPoint"}
 
 Visualize the result of the example above `here <https://gist.github.com/frewsxcv/be02025c1eb3aa2040ee>`__. General information about MultiPoint can be found in `Section 3.1.3`_ and `Appendix A: MultiPoints`_ within `The GeoJSON Format Specification`_.
 
@@ -265,6 +265,22 @@ This encoding/decoding functionality shown in the previous can be extended to cu
 
   >>> geojson.dumps(point_instance, sort_keys=True)  # doctest: +ELLIPSIS
   '{"coordinates": [52.23..., -19.23...], "type": "Point"}'
+
+Default Precision
+~~~~~~~~~~~~~~~~~
+
+GeoJSON Object-based classes in this package have an additional `precision` attribute which rounds off
+coordinates to 6 decimal places (roughly 0.1 meters) by default and can be customized per object.
+
+.. code:: python
+
+  >>> from geojson import Point
+
+  >>> Point((-115.123412341234, 37.123412341234))  # rounded to 6 decimal places by default
+  {"coordinates": [-115.123412, 37.123412], "type": "Point"}
+
+  >>> Point((-115.12341234, 37.12341234), precision=8)  # rounded to 8 decimal places
+  {"coordinates": [-115.12341234, 37.12341234], "type": "Point"}
 
 Helpful utilities
 -----------------

--- a/README.rst
+++ b/README.rst
@@ -49,7 +49,7 @@ Point
   >>> from geojson import Point
 
   >>> Point((-115.81, 37.24))  # doctest: +ELLIPSIS
-  {"coordinates": [-115.81, 37.24], "type": "Point"}
+  {"coordinates": [-115.8..., 37.2...], "type": "Point"}
 
 Visualize the result of the example above `here <https://gist.github.com/frewsxcv/b5768a857f5598e405fa>`__. General information about Point can be found in `Section 3.1.2`_ and `Appendix A: Points`_ within `The GeoJSON Format Specification`_.
 
@@ -64,7 +64,7 @@ MultiPoint
   >>> from geojson import MultiPoint
 
   >>> MultiPoint([(-155.52, 19.61), (-156.22, 20.74), (-157.97, 21.46)])  # doctest: +ELLIPSIS
-  {"coordinates": [[-155.52, 19.61], [-156.22, 20.74], [-157.97, 21.46]], "type": "MultiPoint"}
+  {"coordinates": [[-155.5..., 19.6...], [-156.2..., 20.7...], [-157.9..., 21.4...]], "type": "MultiPoint"}
 
 Visualize the result of the example above `here <https://gist.github.com/frewsxcv/be02025c1eb3aa2040ee>`__. General information about MultiPoint can be found in `Section 3.1.3`_ and `Appendix A: MultiPoints`_ within `The GeoJSON Format Specification`_.
 

--- a/README.rst
+++ b/README.rst
@@ -270,7 +270,7 @@ Default Precision
 ~~~~~~~~~~~~~~~~~
 
 GeoJSON Object-based classes in this package have an additional `precision` attribute which rounds off
-coordinates to 6 decimal places (roughly 0.1 meters) by default and can be customized per object.
+coordinates to 6 decimal places (roughly 0.1 meters) by default and can be customized per object instance.
 
 .. code:: python
 

--- a/geojson/geometry.py
+++ b/geojson/geometry.py
@@ -16,16 +16,21 @@ class Geometry(GeoJSON):
     Represents an abstract base class for a WGS84 geometry.
     """
 
-    def __init__(self, coordinates=None, validate=False, **extra):
+    def __init__(self, coordinates=None, validate=False, precision=6, **extra):
         """
         Initialises a Geometry object.
 
         :param coordinates: Coordinates of the Geometry object.
         :type coordinates: tuple or list of tuple
+        :param validate: If True, raise exception in presence of validation errors.
+        :type validate: boolean
+        :param precision: Number of decimal places for lat/lon coords.
+        :type precision: integer
         """
-
         super(Geometry, self).__init__(**extra)
-        self["coordinates"] = self.clean_coordinates(coordinates or [])
+        self["coordinates"] = [
+            round(coord, precision)
+            for coord in self.clean_coordinates(coordinates or [])]
 
         if validate:
             errors = self.errors()

--- a/geojson/geometry.py
+++ b/geojson/geometry.py
@@ -28,9 +28,8 @@ class Geometry(GeoJSON):
         :type precision: integer
         """
         super(Geometry, self).__init__(**extra)
-        self["coordinates"] = [
-            round(coord, precision)
-            for coord in self.clean_coordinates(coordinates or [])]
+        self["coordinates"] = self.clean_coordinates(
+            coordinates or [], precision)
 
         if validate:
             errors = self.errors()
@@ -38,7 +37,7 @@ class Geometry(GeoJSON):
                 raise ValueError('{}: {}'.format(errors, coordinates))
 
     @classmethod
-    def clean_coordinates(cls, coords):
+    def clean_coordinates(cls, coords, precision):
         if isinstance(coords, cls):
             return coords['coordinates']
 
@@ -47,11 +46,11 @@ class Geometry(GeoJSON):
             coords = [coords]
         for coord in coords:
             if isinstance(coord, (list, tuple)):
-                new_coords.append(cls.clean_coordinates(coord))
+                new_coords.append(cls.clean_coordinates(coord, precision))
             elif isinstance(coord, Geometry):
                 new_coords.append(coord['coordinates'])
             elif isinstance(coord, _JSON_compliant_types):
-                new_coords.append(coord)
+                new_coords.append(round(coord, precision))
             else:
                 raise ValueError("%r is not a JSON compliant number" % coord)
         return new_coords

--- a/geojson/geometry.py
+++ b/geojson/geometry.py
@@ -22,7 +22,7 @@ class Geometry(GeoJSON):
 
         :param coordinates: Coordinates of the Geometry object.
         :type coordinates: tuple or list of tuple
-        :param validate: If True, raise exception in presence of validation errors.
+        :param validate: Raise exception if validation errors are present?
         :type validate: boolean
         :param precision: Number of decimal places for lat/lon coords.
         :type precision: integer

--- a/tests/test_coords.py
+++ b/tests/test_coords.py
@@ -3,11 +3,17 @@ import unittest
 import geojson
 from geojson.utils import coords, map_coords
 
+TOO_PRECISE = (1.12341234, -2.12341234)
+
 
 class CoordsTestCase(unittest.TestCase):
     def test_point(self):
         itr = coords(geojson.Point((-115.81, 37.24)))
         self.assertEqual(next(itr), (-115.81, 37.24))
+
+    def test_point_rounding(self):
+        itr = coords(geojson.Point(TOO_PRECISE))
+        self.assertEqual(next(itr), tuple([round(c, 6) for c in TOO_PRECISE]))
 
     def test_dict(self):
         itr = coords({'type': 'Point', 'coordinates': [-115.81, 37.24]})

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -6,7 +6,6 @@ import unittest
 
 import geojson
 
-COORDINATES = [53.0, -4.0]
 
 class FeaturesTest(unittest.TestCase):
     def test_protocol(self):

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -6,6 +6,7 @@ import unittest
 
 import geojson
 
+COORDINATES = [53.0, -4.0]
 
 class FeaturesTest(unittest.TestCase):
     def test_protocol(self):
@@ -15,13 +16,13 @@ class FeaturesTest(unittest.TestCase):
         f = {
             'type': 'Feature',
             'id': '1',
-            'geometry': {'type': 'Point', 'coordinates': [53, -4]},
+            'geometry': {'type': 'Point', 'coordinates': [53.0, -4.0]},
             'properties': {'title': 'Dict 1'},
         }
 
         json = geojson.dumps(f, sort_keys=True)
         self.assertEqual(json, '{"geometry":'
-                               ' {"coordinates": [53, -4],'
+                               ' {"coordinates": [53.0, -4.0],'
                                ' "type": "Point"},'
                                ' "id": "1",'
                                ' "properties": {"title": "Dict 1"},'
@@ -30,7 +31,7 @@ class FeaturesTest(unittest.TestCase):
         o = geojson.loads(json)
         output = geojson.dumps(o, sort_keys=True)
         self.assertEqual(output, '{"geometry":'
-                                 ' {"coordinates": [53, -4],'
+                                 ' {"coordinates": [53.0, -4.0],'
                                  ' "type": "Point"},'
                                  ' "id": "1",'
                                  ' "properties": {"title": "Dict 1"},'
@@ -49,7 +50,7 @@ class FeaturesTest(unittest.TestCase):
         from geojson.examples import SimpleWebFeature
         feature = SimpleWebFeature(
             id='1',
-            geometry={'type': 'Point', 'coordinates': [53, -4]},
+            geometry={'type': 'Point', 'coordinates': [53.0, -4.0]},
             title='Feature 1', summary='The first feature',
             link='http://example.org/features/1'
         )
@@ -61,10 +62,10 @@ class FeaturesTest(unittest.TestCase):
         self.assertEqual(feature.properties['link'],
                          'http://example.org/features/1')
         self.assertEqual(geojson.dumps(feature.geometry, sort_keys=True),
-                         '{"coordinates": [53, -4], "type": "Point"}')
+                         '{"coordinates": [53.0, -4.0], "type": "Point"}')
 
         # Encoding
-        json = ('{"geometry": {"coordinates": [53, -4],'
+        json = ('{"geometry": {"coordinates": [53.0, -4.0],'
                 ' "type": "Point"},'
                 ' "id": "1",'
                 ' "properties":'
@@ -77,7 +78,7 @@ class FeaturesTest(unittest.TestCase):
         # Decoding
         factory = geojson.examples.create_simple_web_feature
         json = ('{"geometry": {"type": "Point",'
-                ' "coordinates": [53, -4]},'
+                ' "coordinates": [53.0, -4.0]},'
                 ' "id": "1",'
                 ' "properties": {"summary": "The first feature",'
                 ' "link": "http://example.org/features/1",'
@@ -91,7 +92,7 @@ class FeaturesTest(unittest.TestCase):
         self.assertEqual(feature.properties['link'],
                          'http://example.org/features/1')
         self.assertEqual(geojson.dumps(feature.geometry, sort_keys=True),
-                         '{"coordinates": [53, -4], "type": "Point"}')
+                         '{"coordinates": [53.0, -4.0], "type": "Point"}')
 
     def test_geo_interface(self):
         class Thingy(object):
@@ -108,12 +109,12 @@ class FeaturesTest(unittest.TestCase):
                          "geometry": {"type": "Point",
                                       "coordinates": (self.x, self.y)}})
 
-        ob = Thingy('1', 'thingy one', -106, 40)
+        ob = Thingy('1', 'thingy one', -106.0, 40.0)
         self.assertEqual(geojson.dumps(ob.__geo_interface__['geometry'],
                                        sort_keys=True),
-                         '{"coordinates": [-106, 40], "type": "Point"}')
+                         '{"coordinates": [-106.0, 40.0], "type": "Point"}')
         self.assertEqual(geojson.dumps(ob, sort_keys=True),
-                         ('{"geometry": {"coordinates": [-106, 40],'
+                         ('{"geometry": {"coordinates": [-106.0, 40.0],'
                           ' "type": "Point"},'
                           ' "id": "1",'
                           ' "properties": {"title": "thingy one"}}'))

--- a/tests/test_geo_interface.py
+++ b/tests/test_geo_interface.py
@@ -65,21 +65,21 @@ class EncodingDecodingTest(unittest.TestCase):
                     properties={'name': self.name})
 
         self.name = "In N Out Burger"
-        self.latlng = [-54, 4]
+        self.latlng = [-54.0, 4.0]
 
         self.restaurant_nogeo = Restaurant(self.name, self.latlng)
 
         self.restaurant1 = Restaurant1(self.name, self.latlng)
         self.restaurant2 = Restaurant2(self.name, self.latlng)
 
-        self.restaurant_str = ('{"coordinates": [-54, 4],'
+        self.restaurant_str = ('{"coordinates": [-54.0, 4.0],'
                                ' "type": "Point"}')
 
         self.restaurant_feature1 = RestaurantFeature1(self.name, self.latlng)
         self.restaurant_feature2 = RestaurantFeature2(self.name, self.latlng)
 
         self.restaurant_feature_str = ('{"geometry":'
-                                       ' {"coordinates": [-54, 4],'
+                                       ' {"coordinates": [-54.0, 4.0],'
                                        ' "type": "Point"},'
                                        ' "properties":'
                                        ' {"name": "In N Out Burger"},'
@@ -133,13 +133,13 @@ class EncodingDecodingTest(unittest.TestCase):
 
     def test_invalid(self):
         with self.assertRaises(ValueError) as cm:
-            geojson.loads('{"type":"Point", "coordinates":[[-Infinity, 4]]}')
+            geojson.loads('{"type":"Point", "coordinates":[[-Infinity, 4.0]]}')
 
         self.assertIn('is not JSON compliant', str(cm.exception))
 
     def test_mapping(self):
-        self.assertEqual(to_mapping(geojson.Point([1, 2])),
-                         {"coordinates": [1, 2], "type": "Point"})
+        self.assertEqual(to_mapping(geojson.Point([1.0, 2.0])),
+                         {"coordinates": [1.0, 2.0], "type": "Point"})
 
     def test_GeoJSON(self):
         self.assertEqual(None, geojson.GeoJSON().__geo_interface__)


### PR DESCRIPTION
In response to #84:

- [X] Add a precision parameter to the Geometry base class (accessible on all GeoJSON Type subclasses)
- [X] Set default precision to 6 decimal places (~11.1cm)
- [x] Update unit tests to confirm rounding feature
- [x] Update examples in docs to explain rounding feature